### PR TITLE
Caddy server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vagrant
+*.log

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,7 @@ Vagrant.configure('2') do |config|
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.
-  # config.vm.network "forwarded_port", guest: 80, host: 8080
+  config.vm.network 'forwarded_port', guest: 80, host: 8080
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
@@ -64,15 +64,14 @@ Vagrant.configure('2') do |config|
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
-  config.vm.provision "shell", inline: <<-SHELL
+  config.vm.provision 'shell', inline: <<-SHELL
     apt-get install -y python-minimal aptitude
   SHELL
 
   config.vm.provision 'ansible' do |ansible|
     ansible.playbook = 'deploy/playbook.yml'
     ansible.extra_vars = {
-        vagrant: true
+      vagrant: true
     }
   end
-
 end

--- a/deploy/playbook.yml
+++ b/deploy/playbook.yml
@@ -2,7 +2,7 @@
 - name: Создание DTServ на сервере
   hosts: all
   gather_facts: no
-  sudo: yes
+  become: yes
 
   roles:
   - ssh_configuration

--- a/deploy/playbook.yml
+++ b/deploy/playbook.yml
@@ -8,3 +8,4 @@
   - ssh_configuration
   - go
   - dt_serv
+  - caddy_for_dt_serv

--- a/deploy/roles/caddy_for_dt_serv/handlers/main.yml
+++ b/deploy/roles/caddy_for_dt_serv/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart caddy
+  service:
+    name: caddy
+    state: restarted

--- a/deploy/roles/caddy_for_dt_serv/tasks/main.yml
+++ b/deploy/roles/caddy_for_dt_serv/tasks/main.yml
@@ -13,6 +13,12 @@
     name: caddy
     state: latest
 
+- name: Install caddyfile
+  template:
+    src: caddyfile.j2
+    dest: /etc/caddy/caddyfile
+  notify: restart caddy
+
 - name: Enable and start caddy service
   service:
     name: caddy

--- a/deploy/roles/caddy_for_dt_serv/tasks/main.yml
+++ b/deploy/roles/caddy_for_dt_serv/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: Install caddy repo
+  apt_repository:
+    repo: 'ppa:hduran-8/caddy'
+
+- name: Update apt cache
+  apt:
+    update_cache: yes
+    cache_valid_time: 3600
+
+- name: Install caddy http frontend server
+  apt:
+    name: caddy
+    state: latest
+
+- name: Enable and start caddy service
+  service:
+    name: caddy
+    state: started
+    enabled: yes
+

--- a/deploy/roles/caddy_for_dt_serv/templates/caddyfile.j2
+++ b/deploy/roles/caddy_for_dt_serv/templates/caddyfile.j2
@@ -1,0 +1,16 @@
+{% if vagrant %}
+
+*:80
+
+{% else %}
+
+https://dtserv.pimenov.cc
+tls kirill@pimenov.cc
+
+{% endif %}
+
+proxy / localhost:8080 {
+  transparent
+}
+
+gzip


### PR DESCRIPTION
Теперь когда ты делаешь `vagrant up`, твой сервер доступен по `http://localhost:8080`, порт прокидывается Вагрантом.

Кроме того, обрати внимание на ифы в `caddyfile.j2`. Хотелось бы, чтобы ты сам догадался, зачем они там и как работают (и откуда берётся эта переменная `vagrant`).

Ещё прикол — `notify: restart caddy`. Почитай, пожалуйста, про нотифаи в [официальной доке](https://docs.ansible.com/ansible/playbooks_intro.html#handlers-running-operations-on-change), спроси меня если что-то будет непонятно.
Бонусный вопрос тут — как ты думаешь, вот если прямо сейчас задеплоить обновлённую версию `DTserv`, почему ты не увидишь обновлённого поведения в продакшене? Как это исправить?